### PR TITLE
attempt at doing logger reading

### DIFF
--- a/projectApp/logsCsv.txt
+++ b/projectApp/logsCsv.txt
@@ -1,0 +1,8 @@
+{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"URLComponent read: ${csv}"}
+{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"readURLFile read a file\n${JSON.stringify(data.getData())}"}
+{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"loadCSVData has loaded csv data\n${JSON.stringify(this.data)}"}
+{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"${this.name} data is set to ${JSON.stringify(data)}"}
+{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"URLCSVReader has successfully parsed\n${JSON.stringify(timeSeries)}"}
+{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"setName, ${this.name} will now be called ${name}"}
+{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"setYHeader, ${this.name} yHeader is set to ${header}"}
+

--- a/projectApp/logsCsv.txt
+++ b/projectApp/logsCsv.txt
@@ -1,8 +1,19 @@
-{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"URLComponent read: ${csv}"}
-{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"readURLFile read a file\n${JSON.stringify(data.getData())}"}
-{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"loadCSVData has loaded csv data\n${JSON.stringify(this.data)}"}
-{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"${this.name} data is set to ${JSON.stringify(data)}"}
-{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"URLCSVReader has successfully parsed\n${JSON.stringify(timeSeries)}"}
-{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"setName, ${this.name} will now be called ${name}"}
-{"level":30,"time":1740445243264,"pid":24201,"hostname":"Stevens-MacBook-Pro.local","msg":"setYHeader, ${this.name} yHeader is set to ${header}"}
+{"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"URLComponent read: ${csv}"}
+{"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"readURLFile read a file\n${JSON.stringify(data.getData())}"}
+{"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"loadCSVData has loaded csv data\n${JSON.stringify(this.data)}"}
+{"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"${this.name} data is set to ${JSON.stringify(data)}"}
+{"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"URLCSVReader has successfully parsed\n${JSON.stringify(timeSeries)}"}
+{"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"setName, ${this.name} will now be called ${name}"}
+{"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"setYHeader, ${this.name} yHeader is set to ${header}"}
 
+{"level":50,"time":1740454030681,"pid":59082,"hostname":"myHost","name":"Error","errmessage":"url must be .csv or .txt","stack":"errorstack","msg":"test existence"}
+
+{"level":50,"time":1740454030681,"pid":59082,"hostname":"myHost","name":"Error","errmessage":"url must be .csv or .txt","stack":"errorstack","msg":"UrlCSVReader ${url} is not .csv or .txt"}
+{"level":50,"time":1740454030681,"pid":59082,"hostname":"myHost","name":"Error","errmessage":"error rethrow","stack":"errorstack","msg":"loadCSVData error"}
+{"level":50,"time":1740454030681,"pid":59082,"hostname":"myHost","name":"Error","errmessage":"error rethrow","stack":"errorstack","msg":"readURLFile error"}
+
+{"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"LocalCsvReader(file) has read data\n${JSON.stringify(parsed.data)}"}
+{"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"readLocalFile read a file\n${JSON.stringify(data.getData())}"}
+{"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"LoadComponent read: ${file.name.toString()}"}
+
+{"level":50,"time":1740454030681,"pid":59082,"hostname":"myHost","name":"Error","errmessage":"error rethrow","stack":"errorstack","msg":"readLocalFile error"}

--- a/projectApp/logsCsv.txt
+++ b/projectApp/logsCsv.txt
@@ -1,3 +1,6 @@
+{"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"test for log at path ${path}"}
+{"level":50,"time":1740454030681,"pid":59082,"hostname":"myHost","name":"Error","errmessage":"test error","stack":"errorstack","msg":"test for error at path ${path}"}
+
 {"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"URLComponent read: ${csv}"}
 {"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"readURLFile read a file\n${JSON.stringify(data.getData())}"}
 {"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"loadCSVData has loaded csv data\n${JSON.stringify(this.data)}"}
@@ -5,8 +8,6 @@
 {"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"URLCSVReader has successfully parsed\n${JSON.stringify(timeSeries)}"}
 {"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"setName, ${this.name} will now be called ${name}"}
 {"level":30,"time":1740445243264,"pid":12345,"hostname":"myHost","msg":"setYHeader, ${this.name} yHeader is set to ${header}"}
-
-{"level":50,"time":1740454030681,"pid":59082,"hostname":"myHost","name":"Error","errmessage":"url must be .csv or .txt","stack":"errorstack","msg":"test existence"}
 
 {"level":50,"time":1740454030681,"pid":59082,"hostname":"myHost","name":"Error","errmessage":"url must be .csv or .txt","stack":"errorstack","msg":"UrlCSVReader ${url} is not .csv or .txt"}
 {"level":50,"time":1740454030681,"pid":59082,"hostname":"myHost","name":"Error","errmessage":"error rethrow","stack":"errorstack","msg":"loadCSVData error"}

--- a/projectApp/src/models/CSVDataObject.tsx
+++ b/projectApp/src/models/CSVDataObject.tsx
@@ -40,7 +40,7 @@ export class CSVDataObject implements CSVData{
                 this.csvHeaders = headers;
                 this.setYHeader("X");
             }
-            sendLog("info",`loadCSVData has loaded csv data\n${JSON.stringify(this.data)}}`);
+            sendLog("info",`loadCSVData has loaded csv data\n${JSON.stringify(this.data)}`);
         }
         catch(error: unknown) {
             sendError(error, "loadCSVData error");

--- a/projectApp/test/CSVLoaderLogs.test.ts
+++ b/projectApp/test/CSVLoaderLogs.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 import { sendError, sendLog } from "../src/logger-frontend";
 import * as fs from 'fs';
 
@@ -8,11 +8,11 @@ import { fileContainsText } from "./fileParser";
 describe('emulating csvLoader.feature', () => {
     const path = __dirname + '/../logsCsv.txt';
     test('log file exists', () => {
-        const path = __dirname + '/../logs.txt';
+        const path = './logs.txt';
         sendLog("info",`path to log file is ${path}`);
         expect(fs.existsSync(path)).toBe(true);
     });
-    test('emulating scenario: Confirming URL CSV entry', () => {
+    test('emulating scenario: Confirming URL CSV entry', async () => {
         //UrlCsvReader
         const URLCSVReaderSuccess = "URLCSVReader has successfully parsed";
         //CSVDataObject
@@ -23,15 +23,107 @@ describe('emulating csvLoader.feature', () => {
         //CSVReaderModel
         const readURLFileSuccess = "readURLFile read a file";
         //BrowserUI
-        const LoadComponentLog = "URLComponent read:";
-        expect(fileContainsText(path,URLCSVReaderSuccess)).resolves.toBe(true);
-        expect(fileContainsText(path,CSVDataObjectSetData)).resolves.toBe(true);
-        expect(fileContainsText(path,CSVDataObjectSetName)).resolves.toBe(true);
-        expect(fileContainsText(path,CSVDataObjectSetYHeader)).resolves.toBe(true);
-        expect(fileContainsText(path,loadCSVDataSuccess)).resolves.toBe(true);
-        expect(fileContainsText(path,readURLFileSuccess)).resolves.toBe(true);
-        expect(fileContainsText(path,LoadComponentLog)).resolves.toBe(true);
+        const URLComponentLog = "URLComponent read:";
+        await expect(fileContainsText(path,URLCSVReaderSuccess)).resolves.toBe(true);
+        await expect(fileContainsText(path,CSVDataObjectSetData)).resolves.toBe(true);
+        await expect(fileContainsText(path,CSVDataObjectSetName)).resolves.toBe(true);
+        await expect(fileContainsText(path,CSVDataObjectSetYHeader)).resolves.toBe(true);
+        await expect(fileContainsText(path,loadCSVDataSuccess)).resolves.toBe(true);
+        await expect(fileContainsText(path,readURLFileSuccess)).resolves.toBe(true);
+        await expect(fileContainsText(path,URLComponentLog)).resolves.toBe(true);
         //let me know if some other logs are left out
+    });
+
+    test('emulating scenario: Confirming invalid URL CSV entry', async () => {
+        //depends on what counts as invalid
+        //was it a non .csv file?
+        //either it was not .csv, or fetch could not find url, or file was empty, or other error
+        //UrlCsvReader
+        const UrlReaderNotCSV = "is not .csv or .txt";
+        const UrlReaderIsEmpty = "URLCSVReader is empty";
+        const UrlCSVReaderError = "URLCSVReader error";
+        //CSVDataObject
+        const loadCSVDataError = "loadCSVData error";
+        //the error SHOULD be propegated to readURLFile, but it was caught and not rethrown by localCSVData
+        //CSVReaderModel
+        const readURLFileError = "readURLFile error";
+        //again, if the error was caught by readURLFile, it wouldnt be rethrown to BrowserUI
+        //aslo BrowserUI doesnt have a try/catch method, so there is no way to display the error message
+        //BrowserUI
+        const URLComponentLog = "URLComponent read:";
+
+        const anyTrue = Promise.all([
+            fileContainsText(path,UrlReaderNotCSV),
+            fileContainsText(path,UrlReaderIsEmpty),
+            fileContainsText(path,UrlCSVReaderError)
+        ]).then((items) => items.includes(true));
+        await expect(anyTrue).resolves.toBe(true);
+        //expect that loadCSVDataError actually rethrows errors
+        await expect(fileContainsText(path,loadCSVDataError)).resolves.toBe(true);
+        //expect that readURLFileError ctually rethrows errors
+        await expect(fileContainsText(path,readURLFileError)).resolves.toBe(true);
+        //maybe replace this with whatever the error dialog should be
+        await expect(fileContainsText(path,URLComponentLog)).resolves.toBe(true);
+        //let me know if some other logs are left out
+    });
+
+    test('emulating scenario: Confirming Local CSV entry', async () => {
+        //LocalCsvReader
+        const LocalCSVReaderSuccess = "LocalCsvReader(file) has read data";
+        //CSVDataObject
+        const CSVDataObjectSetData = "data is set to";
+        const CSVDataObjectSetName = "will now be called";
+        const CSVDataObjectSetYHeader = "yHeader is set to";
+        const loadCSVDataSuccess = "loadCSVData has loaded csv data";
+        //CSVReaderModel
+        const readLocalFileSuccess = "readLocalFile read a file";
+        //BrowserUI
+        const LoadComponentLog = "LoadComponent read:";
+        await expect(fileContainsText(path,LocalCSVReaderSuccess)).resolves.toBe(true);
+        await expect(fileContainsText(path,CSVDataObjectSetData)).resolves.toBe(true);
+        await expect(fileContainsText(path,CSVDataObjectSetName)).resolves.toBe(true);
+        await expect(fileContainsText(path,CSVDataObjectSetYHeader)).resolves.toBe(true);
+        await expect(fileContainsText(path,loadCSVDataSuccess)).resolves.toBe(true);
+        await expect(fileContainsText(path,readLocalFileSuccess)).resolves.toBe(true);
+        await expect(fileContainsText(path,LoadComponentLog)).resolves.toBe(true);
+        //let me know if some other logs are left out
+    });
+
+    test('emulating scenario: Confirming invalid Local CSV entry', async () => {
+        //depends on what counts as invalid
+        //was it a non .csv file?
+        //either it was not .csv, or fetch could not find url, or file was empty, or other error
+        //LocalCsvReader
+        const LocalReaderNotCSV = "is not .csv or .txt";
+        //there is no method of checking if the file is empty with LocalCsvReader(file:File)
+        const LocalCSVReaderError = "LocalCsvReader(file) has errored for";
+        //CSVDataObject
+        const loadCSVDataError = "loadCSVData error";
+        //the error SHOULD be propegated to readURLFile, but it was caught and not rethrown by localCSVData
+        //CSVReaderModel
+        const readLocalFileError = "readLocalFile error";
+        //again, if the error was caught by readURLFile, it wouldnt be rethrown to BrowserUI
+        //aslo BrowserUI doesnt have a try/catch method, so there is no way to display the error message
+        //BrowserUI
+        const LoadComponentLog = "LoadComponent read:";
+
+        const anyTrue = Promise.all([
+            fileContainsText(path,LocalReaderNotCSV),
+            fileContainsText(path,LocalCSVReaderError)
+        ]).then((items) => items.includes(true));
+        await expect(anyTrue).resolves.toBe(true);
+        //expect that loadCSVDataError actually rethrows errors
+        await expect(fileContainsText(path,loadCSVDataError)).resolves.toBe(true);
+        //expect that readURLFileError ctually rethrows errors
+        await expect(fileContainsText(path,readLocalFileError)).resolves.toBe(true);
+        //maybe replace this with whatever the error dialog should be
+        await expect(fileContainsText(path,LoadComponentLog)).resolves.toBe(true);
+        //let me know if some other logs are left out
+    });
+
+    test('emulating scenario: Deleting a loaded CSV file', async () => {
+        //nothing?
+        expect("There is no delete button yet").toBe("There is no delete button yet");
     });
 
 });

--- a/projectApp/test/CSVLoaderLogs.test.ts
+++ b/projectApp/test/CSVLoaderLogs.test.ts
@@ -1,16 +1,18 @@
 import { describe, expect, test } from "vitest";
-import { sendError, sendLog } from "../src/logger-frontend";
+//import { sendLog } from "../src/logger-frontend";
 import * as fs from 'fs';
 
 import { fileContainsText } from "./fileParser";
 
 
 describe('emulating csvLoader.feature', () => {
-    const path = __dirname + '/../logsCsv.txt';
+    const path = './logsCsv.txt';
     test('log file exists', () => {
-        const path = './logs.txt';
-        sendLog("info",`path to log file is ${path}`);
+        //const testInfo = `path to log file is ${path}`;
+        //sendLog("info",testInfo);
         expect(fs.existsSync(path)).toBe(true);
+        //expect(fileContinsText(path,testInfo));
+        //re-add these when actual gherkin testing is done
     });
     test('emulating scenario: Confirming URL CSV entry', async () => {
         //UrlCsvReader
@@ -48,7 +50,7 @@ describe('emulating csvLoader.feature', () => {
         //CSVReaderModel
         const readURLFileError = "readURLFile error";
         //again, if the error was caught by readURLFile, it wouldnt be rethrown to BrowserUI
-        //aslo BrowserUI doesnt have a try/catch method, so there is no way to display the error message
+        //also BrowserUI doesnt have a try/catch method, so there is no way to display the error message
         //BrowserUI
         const URLComponentLog = "URLComponent read:";
 
@@ -91,7 +93,6 @@ describe('emulating csvLoader.feature', () => {
 
     test('emulating scenario: Confirming invalid Local CSV entry', async () => {
         //depends on what counts as invalid
-        //was it a non .csv file?
         //either it was not .csv, or fetch could not find url, or file was empty, or other error
         //LocalCsvReader
         const LocalReaderNotCSV = "is not .csv or .txt";
@@ -103,7 +104,7 @@ describe('emulating csvLoader.feature', () => {
         //CSVReaderModel
         const readLocalFileError = "readLocalFile error";
         //again, if the error was caught by readURLFile, it wouldnt be rethrown to BrowserUI
-        //aslo BrowserUI doesnt have a try/catch method, so there is no way to display the error message
+        //also BrowserUI doesnt have a try/catch method, so there is no way to display the error message
         //BrowserUI
         const LoadComponentLog = "LoadComponent read:";
 
@@ -121,8 +122,8 @@ describe('emulating csvLoader.feature', () => {
         //let me know if some other logs are left out
     });
 
-    test('emulating scenario: Deleting a loaded CSV file', async () => {
-        //nothing?
+    test('emulating scenario: Deleting a loaded CSV file', () => {
+        //nothing? for now, since button has yet to have delete code implemented
         expect("There is no delete button yet").toBe("There is no delete button yet");
     });
 

--- a/projectApp/test/CSVLoaderLogs.test.ts
+++ b/projectApp/test/CSVLoaderLogs.test.ts
@@ -126,11 +126,4 @@ describe('emulating csvLoader.feature', () => {
         await expect(fileContainsText(path,LoadComponentLog)).resolves.toBe(true);
         //let me know if some other logs are left out
     });
-    /*
-    test('emulating scenario: Deleting a loaded CSV file', async () => {
-        const deleteButtonLog = "log for delete button"
-        await expect(fileContainsText(path,deleteButtonLog)).resolves.toBe(true);
-    });
-    */
-
 });

--- a/projectApp/test/CSVLoaderLogs.test.ts
+++ b/projectApp/test/CSVLoaderLogs.test.ts
@@ -121,10 +121,11 @@ describe('emulating csvLoader.feature', () => {
         await expect(fileContainsText(path,LoadComponentLog)).resolves.toBe(true);
         //let me know if some other logs are left out
     });
-
-    test('emulating scenario: Deleting a loaded CSV file', () => {
-        //nothing? for now, since button has yet to have delete code implemented
-        expect("There is no delete button yet").toBe("There is no delete button yet");
+    /*
+    test('emulating scenario: Deleting a loaded CSV file', async () => {
+        const deleteButtonLog = "log for delete button"
+        await expect(fileContainsText(path,deleteButtonLog)).resolves.toBe(true);
     });
+    */
 
 });

--- a/projectApp/test/CSVLoaderLogs.test.ts
+++ b/projectApp/test/CSVLoaderLogs.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test, vi } from "vitest";
+import { sendError, sendLog } from "../src/logger-frontend";
+import * as fs from 'fs';
+
+import { fileContainsText } from "./fileParser";
+
+
+describe('emulating csvLoader.feature', () => {
+    const path = __dirname + '/../logsCsv.txt';
+    test('log file exists', () => {
+        const path = __dirname + '/../logs.txt';
+        sendLog("info",`path to log file is ${path}`);
+        expect(fs.existsSync(path)).toBe(true);
+    });
+    test('emulating scenario: Confirming URL CSV entry', () => {
+        //CSVDataObject
+        const URLCSVReaderSuccess = "URLCSVReader has successfully parsed";
+        const CSVDataObjectSetData = "data is set to";
+        const CSVDataObjectSetName = "will now be called";
+        const CSVDataObjectSetYHeader = "yHeader is set to";
+        const loadCSVDataSuccess = "loadCSVData has loaded csv data";
+        //CSVReaderModel
+        const readURLFileSuccess = "readURLFile read a file";
+        //BrowserUI
+        const LoadComponentLog = "URLComponent read:";
+        expect(fileContainsText(path,URLCSVReaderSuccess)).resolves.toBe(true);
+        expect(fileContainsText(path,CSVDataObjectSetData)).resolves.toBe(true);
+        expect(fileContainsText(path,CSVDataObjectSetName)).resolves.toBe(true);
+        expect(fileContainsText(path,CSVDataObjectSetYHeader)).resolves.toBe(true);
+        expect(fileContainsText(path,loadCSVDataSuccess)).resolves.toBe(true);
+        expect(fileContainsText(path,readURLFileSuccess)).resolves.toBe(true);
+        expect(fileContainsText(path,LoadComponentLog)).resolves.toBe(true);
+        //let me know if some other logs are left out
+    });
+
+});

--- a/projectApp/test/CSVLoaderLogs.test.ts
+++ b/projectApp/test/CSVLoaderLogs.test.ts
@@ -13,8 +13,9 @@ describe('emulating csvLoader.feature', () => {
         expect(fs.existsSync(path)).toBe(true);
     });
     test('emulating scenario: Confirming URL CSV entry', () => {
-        //CSVDataObject
+        //UrlCsvReader
         const URLCSVReaderSuccess = "URLCSVReader has successfully parsed";
+        //CSVDataObject
         const CSVDataObjectSetData = "data is set to";
         const CSVDataObjectSetName = "will now be called";
         const CSVDataObjectSetYHeader = "yHeader is set to";

--- a/projectApp/test/CSVLoaderLogs.test.ts
+++ b/projectApp/test/CSVLoaderLogs.test.ts
@@ -8,10 +8,15 @@ import { fileContainsText } from "./fileParser";
 describe('emulating csvLoader.feature', () => {
     const path = './logsCsv.txt';
     test('log file exists', () => {
-        //const testInfo = `path to log file is ${path}`;
-        //sendLog("info",testInfo);
+        //const testInfo = `test for log at path ${path}`;
+        //const testError = new Error("test error");
+        //const testErrMessage = `test for error at path ${path}`;
         expect(fs.existsSync(path)).toBe(true);
+        //sendLog("info",testInfo);
         //expect(fileContinsText(path,testInfo));
+        //sendError(testError,testErrMessage);
+        //expect(fileContinsText(path,testError));
+        //expect(fileContinsText(path,testErrMessage));
         //re-add these when actual gherkin testing is done
     });
     test('emulating scenario: Confirming URL CSV entry', async () => {


### PR DESCRIPTION
i think this is what madison wants the logging tests to be like
this test reads logs.txt (currently on logsCsv.txt for vitest purposes) and checks if it reads the following logs
unfortunately, variable referencing like ${this.name} will actually be resolved to the variable value, so these temp logs are not accurate
and fileContainsText wont be able to read ${}, so partial log reading should be sufficient for now
(might be dangerous if some other log uses 'data is set to' for another function)