### PR TITLE
Id3 csv file reader mock

### DIFF
--- a/projectApp/src/components/Csv_Components/CSVReaders.tsx
+++ b/projectApp/src/components/Csv_Components/CSVReaders.tsx
@@ -122,7 +122,6 @@ export function LocalCsvReader(file: File): Promise<Record<string,string | numbe
         //invalid file is thrown by onerror
 
         const reader = new FileReader();
-        if(file.type)
 
         reader.onload = (e) => {
             const fileContent = e.target?.result as string;

--- a/projectApp/tests/unit_tests/__mocks__/mockFileReader.ts
+++ b/projectApp/tests/unit_tests/__mocks__/mockFileReader.ts
@@ -5,7 +5,7 @@ export class MockFileReader {
     onload: ((event: ProgressEvent<FileReader>) => void) | null = null;
     onerror: ((event: ProgressEvent<FileReader>) => void) | null = null;
   
-    async readAsText(file: File) {
+    readAsText(file: File) {
         try {
             const readerContent = (file as unknown as { fileBits: BlobPart[], name: string, options?: FilePropertyBag }).fileBits;
             this.result = readerContent[0] as string;

--- a/projectApp/tests/unit_tests/__mocks__/mockFileReader.ts
+++ b/projectApp/tests/unit_tests/__mocks__/mockFileReader.ts
@@ -1,0 +1,22 @@
+import { sendError } from "../../../src/logger-frontend";
+
+export class MockFileReader {
+    result: string | null = null;
+    onload: ((event: ProgressEvent<FileReader>) => void) | null = null;
+    onerror: ((event: ProgressEvent<FileReader>) => void) | null = null;
+  
+    async readAsText(file: File) {
+        try {
+            const readerContent = (file as unknown as { fileBits: BlobPart[], name: string, options?: FilePropertyBag }).fileBits;
+            this.result = readerContent[0] as string;
+        } catch(err: unknown){
+            sendError(err,"mockFileReader was not able to read the file")
+            this.result = "mockFileReader err"
+        }
+        if (this.onload) {
+          this.onload({ target: this } as unknown as ProgressEvent<FileReader>);
+        }
+    };
+}
+
+export default { MockFileReader }

--- a/projectApp/tests/unit_tests/csvMockFS.test.ts
+++ b/projectApp/tests/unit_tests/csvMockFS.test.ts
@@ -56,7 +56,7 @@ describe("testing fs mocking", () => {
     expect(localHeadersData).toEqual(['Time', 'X', 'Y']);
   })
 
-  test('translating timeSeriesData to and from', async () => {
+  test('translating Record<string,string | number>[] to and from', async () => {
     //defining original Record<string,string | number>[] first, to compare to the data received from localReader
     const path = '/fromTSD.csv';
 

--- a/projectApp/tests/unit_tests/csvMockFS.test.ts
+++ b/projectApp/tests/unit_tests/csvMockFS.test.ts
@@ -61,9 +61,6 @@ describe("testing fs mocking", () => {
     const path = '/fromTSD.csv';
 
     const tsd: Record<string,string | number>[] = [];
-    //feels weird to have an object that only holds one data type
-    //Record<string,string | number> is {key:Record(key,val)}
-    //couldnt it be Record<string,string | number> extends Record, i think its ok to use extend as "renaming"
     const line1: Record<string,string | number> = {Time: '2025-01-01', X: 10, Y: 20};
     const line2: Record<string,string | number> = {Time: '2025-01-03', X: 12, Y: 25};
     const line3: Record<string,string | number> = {Time: '2025-01-05', X: 14, Y: 30};

--- a/projectApp/tests/unit_tests/csvTesting.test.ts
+++ b/projectApp/tests/unit_tests/csvTesting.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 
 import {
-    LocalCSVReader as localReader,
-    LocalCSVHeaders as localHeaders,
     UrlCSVReader as urlReader,
     UrlCSVHeaders as urlHeaders,
     LocalCsvReader as localFileReader
@@ -55,139 +53,6 @@ const localUnevenData       = `${relativePathToFiles}/unevenData.csv`;
 const localDifferentTypes   = `${relativePathToFiles}/differentTypes.csv`;
 const localNotCSV           = `${relativePathToFiles}/notCsv.html`;
 const localEmptyFile        = `${relativePathToFiles}/empty.csv`;
-
-describe("Testing the localCSVReader(string) function", () => {
-    //NOTE: these tests are for testing if it can read and recognize csv files, not for if the csv is formatted correctly
-
-    const regularFileReader: TestFormat<string,Record<string,string | number>[]> = {
-        description: "local path reader:\tdata should be read from existing file",
-        inputVars: localRegularFile,
-        expectSuccess: true,
-        useFunction: localReader
-    };
-    runReaderTest(regularFileReader);
-
-    const regularFileHeaders: TestFormat<string,string[]> = {
-        description: "local headers:\theaders should be read from existing file",
-        inputVars: localRegularFile,
-        expectSuccess: true,
-        useFunction: localHeaders
-    };
-    runReaderTest(regularFileHeaders);
-
-    const fakeFileReader: TestFormat<string,Record<string,string | number>[]> = {
-        description: "local path reader:\tdata should not be read from nonexistant file",
-        inputVars: localFakeFile,
-        expectSuccess: false,
-        useFunction: localReader
-    };
-    runReaderTest(fakeFileReader);
-
-    const fakeFileHeaders: TestFormat<string,string[]> = {
-        description: "local headers:\theaders should not be read from nonexistant file",
-        inputVars: localFakeFile,
-        expectSuccess: false,
-        useFunction: localHeaders
-    };
-    runReaderTest(fakeFileHeaders);
-
-    const oneLessReader: TestFormat<string,Record<string,string | number>[]> = {
-        description: "local path reader:\tdata should be read from file with one less header",
-        inputVars: localOneLessHeader,
-        expectSuccess: true,
-        useFunction: localReader
-    }
-    runReaderTest(oneLessReader);
-
-    const oneLessHeader: TestFormat<string,string[]> = {
-        description: "local headers:\theaders should be read from file with one less header",
-        inputVars: localOneLessHeader,
-        expectSuccess: true,
-        useFunction: localHeaders
-    }
-    runReaderTest(oneLessHeader);
-
-    const oneMoreReader: TestFormat<string,Record<string,string | number>[]> = {
-        description: "local path reader:\tdata should be read from file with one more header",
-        inputVars: localOneMoreHeader,
-        expectSuccess: true,
-        useFunction: localReader
-    }
-    runReaderTest(oneMoreReader);
-
-    const oneMoreHeaders: TestFormat<string,string[]> = {
-        description: "local headers:\theaders should be read from file with one more header",
-        inputVars: localOneMoreHeader,
-        expectSuccess: true,
-        useFunction: localHeaders
-    }
-    runReaderTest(oneMoreHeaders);
-
-    const unevenDataReader: TestFormat<string,Record<string,string | number>[]> = {
-        description: "local path reader:\tdata should be read from file with uneven data",
-        inputVars: localUnevenData,
-        expectSuccess: true,
-        useFunction: localReader
-    }
-    runReaderTest(unevenDataReader);
-
-    const unevenDataHeaders: TestFormat<string,string[]> = {
-        description: "local headers:\theaders should be read from file with uneven data",
-        inputVars: localUnevenData,
-        expectSuccess: true,
-        useFunction: localHeaders
-    }
-    runReaderTest(unevenDataHeaders);
-
-    const differentTypesReader: TestFormat<string,Record<string,string | number>[]> = {
-        description: "local path reader:\tdata should be read from file with different data types",
-        inputVars: localDifferentTypes,
-        expectSuccess: true,
-        useFunction: localReader
-    }
-    runReaderTest(differentTypesReader);
-
-    const differentTypesHeaders: TestFormat<string,string[]> = {
-        description: "local headers:\theaders should be read from file with different data types",
-        inputVars: localDifferentTypes,
-        expectSuccess: true,
-        useFunction: localHeaders
-    }
-    runReaderTest(differentTypesHeaders);
-
-    const inputHtmlReader: TestFormat<string,Record<string,string | number>[]> = {
-        description: "local path reader:\tdata should not be read from non-csv file",
-        inputVars: localNotCSV,
-        expectSuccess: false,
-        useFunction: localReader
-    }
-    runReaderTest(inputHtmlReader);
-
-    const inputHtmlHeaders: TestFormat<string,string[]> = {
-        description: "local headers:\theaders should not be read from non-csv file",
-        inputVars: localNotCSV,
-        expectSuccess: false,
-        useFunction: localHeaders
-    }
-    runReaderTest(inputHtmlHeaders);
-
-    const emptyFileReader: TestFormat<string,Record<string,string | number>[]> = {
-        description: "local path reader:\tdata should be not read from empty csv file",
-        inputVars: localEmptyFile,
-        expectSuccess: false,
-        useFunction: localReader
-    }
-    runReaderTest(emptyFileReader);
-
-    const emptyFileHeaders: TestFormat<string,string[]> = {
-        description: "local headers:\theaders should not be read from empty csv file",
-        inputVars: localEmptyFile,
-        expectSuccess: false,
-        useFunction: localHeaders
-    }
-    runReaderTest(emptyFileHeaders);
-
-});
 
 // apparently FileReader can only exist in the web app environment, it cant be tested in normally in nodejs/vitest
 // so these mocks will simulate FileReader and File
@@ -285,15 +150,6 @@ describe("Testing localCsvReader(file) function", () => {
     }
     runReaderTest(emptyFileReader);
 })
-
-describe("test that localReader(pathstring) and localReader(file) using pathStrToFile creates the same data", () => {
-    test("both should return the same data", async () => {
-      const mockFile = await pathStrToFile(localRegularFile);
-      const result = await localFileReader(mockFile);
-      const localFile = await localReader(localRegularFile);
-      expect(result).toEqual(localFile);
-    });
-  });
 
 //urls used in urlCSVReader and Headers
 const githubID2Dev      = "https://raw.githubusercontent.com/UniversityOfSaskatchewanCMPT371/term-project-2025-team-1/refs/heads/ID2Dev/csvTestFiles";

--- a/projectApp/tests/unit_tests/csvTesting.test.ts
+++ b/projectApp/tests/unit_tests/csvTesting.test.ts
@@ -209,16 +209,17 @@ async function pathStrToFile(filePath: string): Promise<File> {
     let data: string;
     try{
         data = await reader;
-    } catch(err){
+    } catch {
         data = ''
         //for some reason, if await reader throws the error, vitest still receives ENOENT error
+        //vitest cant handle errors outside of expect
         //so instead data will be returned as empty (aka couldnt read)
     }
     return new File([data],filePath,{ type: 'text/csv' });
 }
 
 // These tests should now work in non-browser API
-describe("Testing localCsvReader(file) function", async () => {
+describe("Testing localCsvReader(file) function", () => {
 
     const regularFileReader: TestFormat<File,Record<string,string | number>[]> = {
         description: "local file reader:\tdata should be read from existing file",


### PR DESCRIPTION
## Describe your changes
Created a mock FileReader since the original only works in the browser-api, (not vitest)
this should test how LocalCsvReader(file) works with the mock FileReader
Also fixed a bug in at line 125 in CSVReaders
## Issue ticket number and link
#153
## Explanation of the testing process
The new `LocalCsvReader(file)` tests first takes the filepath and puts its contents into a File. Then it passes it into a `TestFormat<File,Record<string,string|number>>` where it tests for expectSuccess
There is also another test to see if LocalCsvReader(file) returns the same data as LocalCSVReader(path)
## Checklist before requesting a review

- [x] I have added one lead (Dev or Test), and another reviewer (**not** PM)
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

> [!TIP]
> The easier it is to understand what's changed, the quicker your PR will be approved!

> [!IMPORTANT]
> All comments and tweaks suggested by made by reviewers must be reconciled by each member before full approval
